### PR TITLE
Fix attachment filename

### DIFF
--- a/lib/griddler/sendgrid/adapter.rb
+++ b/lib/griddler/sendgrid/adapter.rb
@@ -27,11 +27,13 @@ module Griddler
       end
 
       def attachment_files
-        params.delete('attachment-info')
+        info = JSON.parse params.delete('attachment-info')
         attachment_count = params[:attachments].to_i
-
         attachment_count.times.map do |index|
-          params.delete("attachment#{index + 1}".to_sym)
+          params.delete("attachment#{index + 1}".to_sym).tap{|file|
+            # fix filename
+            file.original_filename = info["attachment#{index + 1 }"]['filename']
+          }
         end
       end
     end


### PR DESCRIPTION
I try to received attachment files which have non-english file name(i.e. Japanese file name). But the file name of multipart header is not correct.

I send question to Sendgrid support team, and he answered "A file name of multipart's header is not correct. Please use `attachment-info`". So I add fix to use `attachment-info` instead of multipart header's file name.
