### PR TITLE
Better parsing of email recipients

### DIFF
--- a/lib/griddler/sendgrid/adapter.rb
+++ b/lib/griddler/sendgrid/adapter.rb
@@ -23,7 +23,16 @@ module Griddler
       attr_reader :params
 
       def recipients(key)
-        ( params[key] || '' ).split(',')
+        raw = ( params[key] || '' )
+        if raw.index(">")
+          raw.split(">,").map do |addr|
+            addr.strip!
+            addr << ">" unless addr.index(">")
+            addr
+          end
+        else
+          raw.split(',')
+        end
       end
 
       def attachment_files

--- a/spec/griddler/sendgrid/adapter_spec.rb
+++ b/spec/griddler/sendgrid/adapter_spec.rb
@@ -51,10 +51,10 @@ describe Griddler::Sendgrid::Adapter, '.normalize_params' do
     normalized_params[:attachments].should be_empty
   end
 
-  it 'wraps to in an array' do
+  it 'splits to into an array' do
     normalized_params = normalize_params(default_params)
 
-    normalized_params[:to].should eq [default_params[:to]]
+    normalized_params[:to].should eq ['"Mr Fugushima at Fugu, Inc" <hi@example.com>', 'Foo bar <foo@example.com>']
   end
 
   it 'wraps cc in an array' do
@@ -73,7 +73,7 @@ describe Griddler::Sendgrid::Adapter, '.normalize_params' do
   def default_params
     {
       text: 'hi',
-      to: 'hi@example.com',
+      to: '"Mr Fugushima at Fugu, Inc" <hi@example.com>, Foo bar <foo@example.com>',
       cc: 'cc@example.com',
       from: 'there@example.com',
     }


### PR DESCRIPTION
Some names or titles have commas in them, which defeats the simple strategy of splitting at a comma.

This actually caused issues for me in a production application.