### PR TITLE
Adding "envelope[:to]" adresses to Griddler::Email#to property

### DIFF
--- a/lib/griddler/sendgrid/adapter.rb
+++ b/lib/griddler/sendgrid/adapter.rb
@@ -12,7 +12,7 @@ module Griddler
 
       def normalize_params
         params.merge(
-          to: recipients(:to),
+          to: recipients(:to) + envelope["to"].to_a,
           cc: recipients(:cc),
           attachments: attachment_files,
         )
@@ -21,6 +21,10 @@ module Griddler
       private
 
       attr_reader :params
+
+      def envelope
+        @envelope ||= JSON.parse(params[:envelope] || '{}')
+      end
 
       def recipients(key)
         ( params[key] || '' ).split(',')

--- a/lib/griddler/sendgrid/adapter.rb
+++ b/lib/griddler/sendgrid/adapter.rb
@@ -1,3 +1,5 @@
+# frozen-string-literal: true
+
 module Griddler
   module Sendgrid
     class Adapter
@@ -12,9 +14,10 @@ module Griddler
 
       def normalize_params
         params.merge(
-          to: recipients(:to) + envelope["to"].to_a,
+          to: recipients(:to) + envelope['to'].to_a,
           cc: recipients(:cc),
           attachments: attachment_files,
+          charsets: charsets
         )
       end
 
@@ -27,7 +30,7 @@ module Griddler
       end
 
       def recipients(key)
-        ( params[key] || '' ).split(',')
+        (params[key] || '').split(',')
       end
 
       def attachment_files
@@ -37,6 +40,14 @@ module Griddler
         attachment_count.times.map do |index|
           params.delete("attachment#{index + 1}".to_sym)
         end
+      end
+
+      def charsets
+        return {} unless params[:charsets].present?
+
+        JSON.parse(params[:charsets]).symbolize_keys
+      rescue JSON::ParserError
+        {}
       end
     end
   end


### PR DESCRIPTION
So, I had the following problem: 

I handle the creation of posts on lists by email with your gem. The way I decide which list to post is the token of the TO email property (with a pattern like list1@yolo.com). After a while, the users decided to link the list's email with a google group account. This caused some problems, because the TO property came with the groups email (because that's the original TO, I guess).

After a while I discovered that the TO I needed was in the envelope param.

So I did this change.

I don't know if you guys plan to just accept this change, due to the (I know) at least strange nature of it.

Is there another way you guys solve this kind of problem? If not, can you think about another way to solve it that is not that strange? Store the envelope, maybe?
