### PR TITLE
Delete `style` node from html when extracting text from html

### DIFF
--- a/griddler-sendgrid.gemspec
+++ b/griddler-sendgrid.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
 
   spec.add_dependency 'griddler'
+  spec.add_dependency 'nokogiri'
 end

--- a/lib/griddler/sendgrid/adapter.rb
+++ b/lib/griddler/sendgrid/adapter.rb
@@ -12,6 +12,7 @@ module Griddler
 
       def normalize_params
         params.merge(
+          text: text,
           to: recipients(:to),
           cc: recipients(:cc),
           bcc: get_bcc,
@@ -22,6 +23,23 @@ module Griddler
       private
 
       attr_reader :params
+
+      def text
+        params[:text].presence || extract_text_from_html
+      end
+
+      def extract_text_from_html
+        return "" unless params[:html].present?
+
+        doc = Nokogiri::HTML.parse(params[:html])
+
+        # otherwise styles come out in the text
+        if doc.at_css("style").present?
+          doc.at_css("style").remove
+        end
+
+        doc.text.strip
+      end
 
       def recipients(key)
         raw = ( params[key] || '' )

--- a/spec/griddler/sendgrid/adapter_spec.rb
+++ b/spec/griddler/sendgrid/adapter_spec.rb
@@ -97,6 +97,26 @@ describe Griddler::Sendgrid::Adapter, '.normalize_params' do
     normalized_params[:bcc].should eq []
   end
 
+  it 'extracts text from html when text param is blank' do
+    params = default_params.merge text: nil, html: <<-EOF
+<style type="text/css">
+  .my-sweet-class { color: red; }
+</style>
+<div>
+  <p>Yo,</p>
+  <p>Sup?</p>
+  <br />
+</div>
+<div>
+  <p>Yours truly,</p>
+  <p>Joe</p>
+</div>
+    EOF
+
+    email = Griddler::Email.new(normalize_params params)
+    email.body.should eq("Yo,\n  Sup?\n  \n\n\n  Yours truly,\n  Joe")
+  end
+
   def default_params
     {
       text: 'hi',


### PR DESCRIPTION
Sometimes (I assume due to lame email clients), the text param is blank.

In these cases, we can extract the text from the html portion of the message.
