### PR TITLE
Removes the explicit griddler dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Installation
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'griddler'
 gem 'griddler-sendgrid'
 ```
 


### PR DESCRIPTION
It is declared into `gemspec` https://github.com/thoughtbot/griddler-sendgrid/blob/master/griddler-sendgrid.gemspec#L23