### PR TITLE
Fix attachment filename

### DIFF
--- a/lib/griddler/sendgrid/adapter.rb
+++ b/lib/griddler/sendgrid/adapter.rb
@@ -61,12 +61,31 @@ module Griddler
       end
 
       def attachment_files
-        params.delete('attachment-info')
-        attachment_count = params[:attachments].to_i
-
         attachment_count.times.map do |index|
-          params.delete("attachment#{index + 1}".to_sym)
+          extract_file_at(index)
         end
+      end
+
+      def attachment_count
+        params[:attachments].to_i
+      end
+
+      def extract_file_at(index)
+        filename = attachment_filename(index)
+
+        params.delete("attachment#{index + 1}".to_sym).tap do |file|
+          if filename.present?
+            file.original_filename = filename
+          end
+        end
+      end
+
+      def attachment_filename(index)
+        attachment_info.fetch("attachment#{index + 1}", {})["filename"]
+      end
+
+      def attachment_info
+        @attachment_info ||= JSON.parse(params.delete("attachment-info") || "{}")
       end
     end
   end

--- a/spec/griddler/sendgrid/adapter_spec.rb
+++ b/spec/griddler/sendgrid/adapter_spec.rb
@@ -23,15 +23,15 @@ describe Griddler::Sendgrid::Adapter, '.normalize_params' do
       attachment2: upload_2,
      'attachment-info' => <<-eojson
         {
-          'attachment2': {
-            'filename': 'photo2.jpg',
-            'name': 'photo2.jpg',
-            'type': 'image/jpeg'
+          "attachment2": {
+            "filename": "photo2.jpg",
+            "name": "photo2.jpg",
+            "type": "image/jpeg"
           },
-          'attachment1': {
-            'filename': 'photo1.jpg',
-            'name': 'photo1.jpg',
-            'type': 'image/jpeg'
+          "attachment1": {
+            "filename": "photo1.jpg",
+            "name": "photo1.jpg",
+            "type": "image/jpeg"
           }
         }
       eojson
@@ -42,6 +42,33 @@ describe Griddler::Sendgrid::Adapter, '.normalize_params' do
     normalized_params.should_not have_key(:attachment1)
     normalized_params.should_not have_key(:attachment2)
     normalized_params.should_not have_key(:attachment_info)
+  end
+
+  it "uses sendgrid attachment info for filename" do
+    params = default_params.merge(
+      attachments: "2",
+      attachment1: upload_1,
+      attachment2: upload_2,
+      "attachment-info" => <<-eojson
+        {
+          "attachment2": {
+            "filename": "sendgrid-filename2.jpg",
+            "name": "photo2.jpg",
+            "type": "image/jpeg"
+          },
+          "attachment1": {
+            "filename": "sendgrid-filename1.jpg",
+            "name": "photo1.jpg",
+            "type": "image/jpeg"
+          }
+        }
+      eojson
+    )
+
+    attachments = normalize_params(params)[:attachments]
+
+    attachments.first.original_filename.should eq "sendgrid-filename1.jpg"
+    attachments.second.original_filename.should eq "sendgrid-filename2.jpg"
   end
 
   it 'has no attachments' do


### PR DESCRIPTION
Credit to @mzp - #6

Sendgrid sometimes cuts off filenames, so the official recommendation is
to use the filename from `attachment-info`.