### PR TITLE
Fix Parse Error for UTF-8

### DIFF
--- a/lib/griddler/sendgrid/adapter.rb
+++ b/lib/griddler/sendgrid/adapter.rb
@@ -24,7 +24,8 @@ module Griddler
       attr_reader :params
 
       def recipients(key)
-        Mail::AddressList.new(params[key] || '').addresses
+        encoded = Mail::Encodings.address_encode(params[key] || '')
+        Mail::AddressList.new(encoded).addresses
       end
 
       def get_bcc


### PR DESCRIPTION
I had a problem parsing emails with UTF-8 characters such as ñ, so I encoded them right before using **Mail::AddressList.new** and now it works.

`def recipients(key)
encoded = Mail::Encodings.address_encode(params[key] || '')
Mail::AddressList.new(encoded).addresses
end`
