### PR TITLE
Expose charsets as Hash in normalized params

### DIFF
--- a/lib/griddler/sendgrid/adapter.rb
+++ b/lib/griddler/sendgrid/adapter.rb
@@ -16,6 +16,7 @@ module Griddler
           cc: recipients(:cc).map(&:format),
           bcc: get_bcc,
           attachments: attachment_files,
+          charsets: charsets
         )
       end
 
@@ -39,6 +40,14 @@ module Griddler
       def bcc_from_envelope
         JSON.parse(params[:envelope])["to"] if params[:envelope].present?
       end
+
+      def charsets
+        return {} unless params[:charsets].present?
+        JSON.parse(params[:charsets]).symbolize_keys
+      rescue JSON::ParserError
+        {}
+      end
+
 
       def attachment_files
         attachment_count.times.map do |index|

--- a/spec/griddler/sendgrid/adapter_spec.rb
+++ b/spec/griddler/sendgrid/adapter_spec.rb
@@ -14,6 +14,7 @@ describe Griddler::Sendgrid::Adapter, '.normalize_params' do
       to: 'Hello World <hi@example.com>',
       cc: 'emily@example.com',
       from: 'There <there@example.com>',
+      charsets: { to: 'UTF-8', text: 'iso-8859-1' }.to_json
     }
 
   it 'changes attachments to an array of files' do
@@ -129,6 +130,26 @@ describe Griddler::Sendgrid::Adapter, '.normalize_params' do
     normalized_params[:bcc].should eq []
   end
 
+  it 'returns the charsets as a hash' do
+    normalized_params = normalize_params(default_params)
+    charsets = normalized_params[:charsets]
+
+    charsets.should be_present
+    charsets[:text].should eq 'iso-8859-1'
+    charsets[:to].should eq 'UTF-8'
+  end
+
+  it 'does not explode if charsets is not JSON-able' do
+    params = default_params.merge(charsets: 'This is not JSON')
+
+    normalize_params(params)[:charsets].should eq({})
+  end
+
+  it 'defaults charsets to an empty hash if it is not specified in params' do
+    params = default_params.except(:charsets)
+    normalize_params(params)[:charsets].should eq({})
+  end
+
   def default_params
     {
       text: 'hi',
@@ -136,6 +157,7 @@ describe Griddler::Sendgrid::Adapter, '.normalize_params' do
       cc: 'cc@example.com',
       from: 'there@example.com',
       envelope: "{\"to\":[\"johny@example.com\"], \"from\": [\"there@example.com\"]}",
+      charsets: { to: 'UTF-8', text: 'iso-8859-1' }.to_json
     }
   end
 end


### PR DESCRIPTION
Parse the JSON string and return a Hash with symbol keys
for ease of use by Griddler when encoding strings later on.

We are currently running into an issue where we receive bodies
containing non-UTF8 characters. We want to convert them to UTF8
using String#encode, but without knowing the source encoding, we
cannot do this correctly. This surfaces the encodings that were
pulled out by SendGrid so that we can access them from the
Griddler Email.