### PR TITLE
Add support for Sendgrid spam check

### DIFF
--- a/lib/griddler/sendgrid/adapter.rb
+++ b/lib/griddler/sendgrid/adapter.rb
@@ -24,8 +24,7 @@ module Griddler
       attr_reader :params
 
       def recipients(key)
-        encoded = Mail::Encodings.address_encode(params[key] || '')
-        Mail::AddressList.new(encoded).addresses
+        Mail::AddressList.new(params[key] || '').addresses
       end
 
       def get_bcc

--- a/lib/griddler/sendgrid/adapter.rb
+++ b/lib/griddler/sendgrid/adapter.rb
@@ -16,6 +16,10 @@ module Griddler
           cc: recipients(:cc).map(&:format),
           bcc: get_bcc,
           attachments: attachment_files,
+          spam_report: {
+            report: params[:spam_report],
+            score: params[:spam_score],
+          },
         )
       end
 

--- a/spec/griddler/sendgrid/adapter_spec.rb
+++ b/spec/griddler/sendgrid/adapter_spec.rb
@@ -129,6 +129,15 @@ describe Griddler::Sendgrid::Adapter, '.normalize_params' do
     normalized_params[:bcc].should eq []
   end
 
+  it 'normalizes the spam report into a griddler friendly format' do
+    normalized_params = normalize_params(default_params)
+
+    normalized_params[:spam_report].should eq({
+      score: '1.234',
+      report: 'Some spam report',
+    })
+  end
+
   def default_params
     {
       text: 'hi',
@@ -136,6 +145,8 @@ describe Griddler::Sendgrid::Adapter, '.normalize_params' do
       cc: 'cc@example.com',
       from: 'there@example.com',
       envelope: "{\"to\":[\"johny@example.com\"], \"from\": [\"there@example.com\"]}",
+      spam_score: '1.234',
+      spam_report: 'Some spam report',
     }
   end
 end

--- a/spec/integration/email_spec.rb
+++ b/spec/integration/email_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe Griddler::Email, '#to_h' do
+  it 'accepts normalized params from Griddler::Sendgrid::Adapter' do
+    normalized_params = Griddler::Sendgrid::Adapter.normalize_params(default_params)
+    email = Griddler::Email.new(normalized_params)
+
+    email_properties = email.to_h
+
+    expect(email_properties[:subject]).to eq 'Some subject'
+    expect(email_properties[:spam_score]).to eq '1.234'
+  end
+
+  def default_params
+    {
+      subject: 'Some subject',
+      text: 'hi',
+      to: '"Mr Fugushima at Fugu, Inc" <hi@example.com>, Foo bar <foo@example.com>, Eichhörnchen <squirrel@example.com>, <no-name@example.com>',
+      cc: 'cc@example.com',
+      from: 'there@example.com',
+      envelope: "{\"to\":[\"johny@example.com\"], \"from\": [\"there@example.com\"]}",
+      spam_score: '1.234',
+      spam_report: 'Some spam report',
+    }
+  end
+end


### PR DESCRIPTION
Spam reports were added in thoughtbot/griddler#283. This PR:

- Adds support for Sendgrid's spam report format.
- Adds an integration test to verify that enabling spam checks no longer breaks integration with Griddler.
- Fixes broken test suite by reverting adapter changes in #26, but keeping test to verify UTF-8 encoding still works.