### PR TITLE
Updating Sendgrid API link (I missed the one in the top of the readme)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Griddler::Sendgrid
 This is an adapter that allows [Griddler](https://github.com/thoughtbot/griddler) to be used with
 [SendGrid's Parse API].
 
-[SendGrid's Parse API]: http://sendgrid.com/docs/API_Reference/Webhooks/parse.html
+[SendGrid's Parse API]: https://sendgrid.com/docs/for-developers/parsing-email/setting-up-the-inbound-parse-webhook/
 
 Installation
 ------------


### PR DESCRIPTION
I just realised in https://github.com/thoughtbot/griddler-sendgrid/pull/32 I missed the link at the top of the readme.

Sorry! 