### PR TITLE
Rescue Mail::AddressList parse errors

### DIFF
--- a/lib/griddler/sendgrid/adapter.rb
+++ b/lib/griddler/sendgrid/adapter.rb
@@ -31,6 +31,8 @@ module Griddler
 
       def recipients(key)
         Mail::AddressList.new(params[key] || '').addresses
+      rescue Mail::Field::IncompleteParseError
+        []
       end
 
       def get_bcc

--- a/spec/griddler/sendgrid/adapter_spec.rb
+++ b/spec/griddler/sendgrid/adapter_spec.rb
@@ -145,6 +145,12 @@ describe Griddler::Sendgrid::Adapter, '.normalize_params' do
     normalize_params(params)[:charsets].should eq({})
   end
 
+  it 'does not explode if address is not parseable' do
+    params = default_params.merge(cc: '"Closing Bracket Missing For Some Reason" <hi@example.com')
+
+    normalize_params(params)[:cc].should eq([])
+  end
+
   it 'defaults charsets to an empty hash if it is not specified in params' do
     params = default_params.except(:charsets)
     normalize_params(params)[:charsets].should eq({})


### PR DESCRIPTION
If a malformed email address makes it's way to `normalize_params` it currently explodes resulting in a 500 which Sendgrid retries for 72 hours. If a few of these come in per day the resulting errors snowball pretty quickly. The email will never properly parse, of course, so retrying is futile. 

We've been using `griddler-sendgrid` for quite a few years now and for whatever reason we've been getting inundated with these the last week or so, had not seen it before! Maybe something changed at Sendgrid? In either case we think this is probably the right behavior, `charsets` method does the same. 