### PR TITLE
Add attachment data with content ids

### DIFF
--- a/lib/griddler/sendgrid/adapter.rb
+++ b/lib/griddler/sendgrid/adapter.rb
@@ -16,12 +16,12 @@ module Griddler
           cc: recipients(:cc).map(&:format),
           bcc: get_bcc,
           attachments: attachment_files,
+          attachment_data: attachment_data,
           charsets: charsets,
           spam_report: {
             report: params[:spam_report],
             score: params[:spam_score],
           }
-
         )
       end
 
@@ -54,6 +54,15 @@ module Griddler
         {}
       end
 
+      def attachment_data
+        attachment_count.times.map do |index|
+          {
+            file: extract_file_at(index),
+            type: attachment_info_at(index)['type'],
+            content_id: attachment_info_at(index)['content-id']
+          }
+        end
+      end
 
       def attachment_files
         attachment_count.times.map do |index|
@@ -66,21 +75,20 @@ module Griddler
       end
 
       def extract_file_at(index)
-        filename = attachment_filename(index)
-
-        params.delete("attachment#{index + 1}".to_sym).tap do |file|
+        filename = attachment_info_at(index)['filename']
+        params.fetch("attachment#{index + 1}".to_sym).tap do |file|
           if filename.present?
             file.original_filename = filename
           end
         end
       end
 
-      def attachment_filename(index)
-        attachment_info.fetch("attachment#{index + 1}", {})["filename"]
+      def attachment_info_at(index)
+        attachment_info.fetch("attachment#{index + 1}", {})
       end
 
       def attachment_info
-        @attachment_info ||= JSON.parse(params.delete("attachment-info") || "{}")
+        @attachment_info ||= JSON.parse(params["attachment-info"] || "{}")
       end
     end
   end

--- a/lib/griddler/sendgrid/adapter.rb
+++ b/lib/griddler/sendgrid/adapter.rb
@@ -16,7 +16,9 @@ module Griddler
           cc: recipients(:cc).map(&:format),
           bcc: get_bcc,
           attachments: attachment_files,
-          attachment_data: attachment_data,
+          vendor_specific: {
+            attachment_info: processed_attachment_info
+          },
           charsets: charsets,
           spam_report: {
             report: params[:spam_report],
@@ -54,7 +56,7 @@ module Griddler
         {}
       end
 
-      def attachment_data
+      def processed_attachment_info
         attachment_count.times.map do |index|
           {
             file: extract_file_at(index),

--- a/spec/griddler/sendgrid/adapter_spec.rb
+++ b/spec/griddler/sendgrid/adapter_spec.rb
@@ -27,7 +27,8 @@ describe Griddler::Sendgrid::Adapter, '.normalize_params' do
           "attachment2": {
             "filename": "photo2.jpg",
             "name": "photo2.jpg",
-            "type": "image/jpeg"
+            "type": "image/jpeg",
+            "content-id": "ccce-eeee-aaac"
           },
           "attachment1": {
             "filename": "photo1.jpg",
@@ -40,9 +41,8 @@ describe Griddler::Sendgrid::Adapter, '.normalize_params' do
 
     normalized_params = normalize_params(params)
     normalized_params[:attachments].should eq [upload_1, upload_2]
-    normalized_params.should_not have_key(:attachment1)
-    normalized_params.should_not have_key(:attachment2)
-    normalized_params.should_not have_key(:attachment_info)
+    normalized_params.should have_key(:attachment_data)
+    normalized_params[:attachment_data].should be_present
   end
 
   it "uses sendgrid attachment info for filename" do


### PR DESCRIPTION
The content ids is valuable information that we should be able to reliable access from the parsed email. this pr adds an array of hashes with the content id, type and file instead of just an array of files, while keeping the attachment array we already use in griddler.  This can be useful when using a separate email class with this data. 

Todo: I still need to figure out how to make this work the default email class in griddler, just opening this pr to check how feasible is this.