### PR TITLE
Fix invalid byte sequence in UTF-8 for sendgrid

### DIFF
--- a/lib/griddler/sendgrid/adapter.rb
+++ b/lib/griddler/sendgrid/adapter.rb
@@ -76,7 +76,13 @@ module Griddler
       end
 
       def attachment_filename(index)
-        attachment_info.fetch("attachment#{index + 1}", {})["filename"]
+        filename = attachment_info.fetch("attachment#{index + 1}", {})["filename"]
+
+        if filename && !filename.valid_encoding?
+          filename.force_encoding('ISO-8859-1').encode('UTF-8')
+        else
+          filename
+        end
       end
 
       def attachment_info

--- a/lib/griddler/sendgrid/adapter.rb
+++ b/lib/griddler/sendgrid/adapter.rb
@@ -20,7 +20,7 @@ module Griddler
           spam_report: {
             report: params[:spam_report],
             score: params[:spam_score],
-          }
+          },
           text: params[:text]&.to_s&.force_encoding(Encoding::UTF_8)
         )
       end

--- a/lib/griddler/sendgrid/adapter.rb
+++ b/lib/griddler/sendgrid/adapter.rb
@@ -11,7 +11,25 @@ module Griddler
       end
 
       def normalize_params
-        params.transform_values! { |v| v.is_a?(String) ? to_utf8(v) : v }
+        params.merge!(
+          headers: to_utf8(params[:headers]),
+          dkim: to_utf8(params[:dkim]),
+          "content-ids": to_utf8(params[:"content-ids"]),
+          email: to_utf8(params[:email]),
+          to: to_utf8(params[:to]),
+          html: to_utf8(params[:html]),
+          from: to_utf8(params[:from]),
+          sender_ip: to_utf8(params[:sender_ip]),
+          text: to_utf8(params[:text]),
+          spam_report: to_utf8(params[:spam_report]),
+          envelope: to_utf8(params[:envelope]),
+          attachments: to_utf8(params[:attachments]),
+          subject: to_utf8(params[:subject]),
+          spam_score: to_utf8(params[:spam_score]),
+          "attachment-info": to_utf8(params["attachment-info"]),
+          charsets: to_utf8(params[:charsets]),
+          spf: to_utf8(params[:spf])
+        )
 
         params.merge(
           to: recipients(:to).map(&:format),
@@ -86,11 +104,11 @@ module Griddler
       end
 
       def to_utf8(str)
-        str = str.force_encoding(Encoding::UTF_8)
-        return str if str.valid_encoding?
+        str = str&.force_encoding(Encoding::UTF_8)
+        return str if str&.valid_encoding?
 
-        str = str.force_encoding(Encoding::ISO_8859_1)
-        str.encode(Encoding::UTF_8, :invalid => :replace, :undef => :replace)
+        str = str&.force_encoding(Encoding::ISO_8859_1)
+        str&.encode(Encoding::UTF_8, :invalid => :replace, :undef => :replace)
       end
     end
   end

--- a/lib/griddler/sendgrid/adapter.rb
+++ b/lib/griddler/sendgrid/adapter.rb
@@ -78,7 +78,7 @@ module Griddler
       end
 
       def attachment_filename(index)
-        filename = attachment_info.fetch("attachment#{index + 1}", {})["filename"]
+        attachment_info.fetch("attachment#{index + 1}", {})["filename"]
       end
 
       def attachment_info

--- a/lib/griddler/sendgrid/adapter.rb
+++ b/lib/griddler/sendgrid/adapter.rb
@@ -21,7 +21,7 @@ module Griddler
             report: params[:spam_report],
             score: params[:spam_score],
           }
-
+          text: params[:text]&.to_s&.force_encoding(Encoding::UTF_8)
         )
       end
 

--- a/spec/griddler/sendgrid/adapter_spec.rb
+++ b/spec/griddler/sendgrid/adapter_spec.rb
@@ -165,6 +165,33 @@ describe Griddler::Sendgrid::Adapter, '.normalize_params' do
     })
   end
 
+  it 'parses sendgrid filename correctly' do
+    params = default_params.merge(
+      attachments: "2",
+      attachment1: upload_1,
+      attachment2: upload_2,
+      "attachment-info" => <<-eojson
+        {
+          "attachment2": {
+            "filename": "\xc3\x28.jpg",
+            "name": "photo2.jpg",
+            "type": "image/jpeg"
+          },
+          "attachment1": {
+            "filename": "sendgrid-filename1.jpg",
+            "name": "photo1.jpg",
+            "type": "image/jpeg"
+          }
+        }
+      eojson
+    )
+
+    attachments = normalize_params(params)[:attachments]
+
+    attachments.first.original_filename.should eq "sendgrid-filename1.jpg"
+    attachments.second.original_filename.should eq "Ã(.jpg"
+  end
+
   def default_params
     {
       text: 'hi',


### PR DESCRIPTION
There is an error when the filename for sendgrid contains an invalid character, for example "test\xc3\x28.pdf".